### PR TITLE
fix rendering fb purchase event

### DIFF
--- a/services/FbPixel_PurchaseService.php
+++ b/services/FbPixel_PurchaseService.php
@@ -19,8 +19,13 @@ class FbPixel_PurchaseService extends BaseApplicationComponent
 
     public function checkFlash()
     {
-        if (craft()->userSession->hasFlash(self::FLASH_NAME)) {
+        if (craft()->userSession->hasFlash(self::FLASH_NAME, null, true)) {
             $orderId = craft()->userSession->getFlash(self::FLASH_NAME, null, true);
+        } else {
+            $orderId = craft()->getRequest()->getParam('order');
+        }
+        if ($orderId && craft()->userSession->get($orderId) !== true) {
+            craft()->userSession->set($orderId, true);
             $order = craft()->commerce_orders->getOrderById($orderId);
             $this->order = $order;
             $this->addHook();

--- a/services/FbPixel_PurchaseService.php
+++ b/services/FbPixel_PurchaseService.php
@@ -24,8 +24,8 @@ class FbPixel_PurchaseService extends BaseApplicationComponent
         } else {
             $orderId = craft()->getRequest()->getParam('order');
         }
-        if ($orderId && craft()->userSession->get($orderId) !== true) {
-            craft()->userSession->set($orderId, true);
+        if ($orderId && craft()->httpSession->get($orderId) !== true) {
+            craft()->httpSession->set($orderId, true);
             $order = craft()->commerce_orders->getOrderById($orderId);
             $this->order = $order;
             $this->addHook();


### PR DESCRIPTION
fix rendering fb purchase event when order is completed on another request.

Scenario:
Client uses a payment provider which confirms the payment with a webhook.
In that case the flash event happens during the request of the webhook.
Fb pixel purchase event is then not being triggered because webhook does not render any template.
My solution to that is to trigger the fb purchase event on checkout page where the order_id is in the url as parameter. Then I set an http session parameter so the purchase event is triggered only once.